### PR TITLE
Specify colors of a number of UI elements

### DIFF
--- a/app/src/main/res/drawable/popup_menu_background.xml
+++ b/app/src/main/res/drawable/popup_menu_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="?attr/colorPrimary"/>
+    <corners
+        android:bottomLeftRadius="6dp"
+        android:bottomRightRadius="6dp"
+        android:topLeftRadius="6dp"
+        android:topRightRadius="6dp" />
+</shape>

--- a/app/src/main/res/layout/about_card_translations.xml
+++ b/app/src/main/res/layout/about_card_translations.xml
@@ -27,7 +27,8 @@
             android:layout_height="wrap_content"
             android:paddingStart="16dp"
             android:paddingEnd="16dp"
-            android:text="@string/translators_list" />
+            android:text="@string/translators_list"
+            android:textColor="@color/light_grey" />
 
         <ImageView
             android:id="@+id/kanna_image"

--- a/app/src/main/res/layout/song_details.xml
+++ b/app/src/main/res/layout/song_details.xml
@@ -85,7 +85,8 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@{song.albumsString ?? @string/song_info_blank}" />
+                android:text="@{song.albumsString ?? @string/song_info_blank}"
+                android:textColor="@color/white"/>
 
         </LinearLayout>
 
@@ -105,7 +106,8 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@{song.sourcesString ?? @string/song_info_blank}" />
+                android:text="@{song.sourcesString ?? @string/song_info_blank}"
+                android:textColor="@color/white"/>
 
         </LinearLayout>
 

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -6,6 +6,7 @@
         <item name="android:background">@color/darker_grey</item>
         <item name="android:textColorPrimary">@color/white</item>
         <item name="android:textColor">@color/white</item>
+        <item name="colorOnSurface">@color/white</item>
         <item name="colorAccent">@color/colorAccent</item>
 
         <item name="buttonBarPositiveButtonStyle">@style/Theme.Widget.Button.Accent</item>
@@ -26,6 +27,10 @@
         <item name="iconTint">@color/white_button_states</item>
         <item name="rippleColor">?attr/colorAccent</item>
         <item name="strokeColor">@color/white_button_states</item>
+    </style>
+    <style name="Theme.Widget.PopupMenu" parent="ThemeOverlay.AppCompat.Dark">
+        <item name="android:popupBackground">@drawable/popup_menu_background</item>
+        <item name="android:textColorPrimary">@color/white</item>
     </style>
 
     <!-- Textboxes -->

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.App" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.App" parent="Theme.MaterialComponents.Light.DarkActionBar">
         <!-- Accent color -->
         <item name="colorPrimary">@color/grey</item>
         <item name="colorOnPrimary">@color/white</item>
@@ -25,6 +25,7 @@
 
         <!-- UI widget theming -->
         <item name="elevationOverlayEnabled">false</item>
+        <item name="actionOverflowMenuStyle">@style/Theme.Widget.PopupMenu</item>
         <item name="alertDialogTheme">@style/Theme.Widget.Dialog</item>
         <item name="dialogTheme">@style/Theme.Widget.Dialog</item>
         <item name="materialButtonStyle">@style/Theme.Widget.Button</item>


### PR DESCRIPTION
This fixes a number of broken UI elements in Android Q's Light/Dark mode.
Due the reliance on default colours - these UI elements currently.

This should fix the UI elements mentioned in issue #40 

Tested visually:

<img src="https://user-images.githubusercontent.com/587220/86633311-6bbaf380-bfc8-11ea-9146-9ca1c37ddedf.png" height=600>
<img src="https://user-images.githubusercontent.com/587220/86633393-82614a80-bfc8-11ea-91b3-f20b383ebc02.png" height=600>
<img src="https://user-images.githubusercontent.com/587220/86633398-842b0e00-bfc8-11ea-9fda-f77b9eba6a3e.png" height=600>
<img src="https://user-images.githubusercontent.com/587220/86633400-855c3b00-bfc8-11ea-894a-21429c1e0c82.png" height=600>
