### PR TITLE
Update F-Droid & Google Play brand badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 ## Download
 
 <a href="https://play.google.com/store/apps/details?id=me.echeung.moemoekyun">
-  <img height="50" alt="Get it on Google Play"
-       src="https://play.google.com/intl/en_us/badges/images/apps/en-play-badge.png" />
+  <img height="80" alt="Get it on Google Play"
+       src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" />
 </a>
 
 <a href="https://f-droid.org/app/me.echeung.moemoekyun.fdroid">
-  <img height="50" alt="Get it on F-Droid"
-       src="https://i.imgur.com/um29KX1.png">
+  <img height="80" alt="Get it on F-Droid"
+       src="https://f-droid.org/badge/get-it-on.png">
 </a>
 
 


### PR DESCRIPTION
This change modifies the `README.md` file to include updated badges.

Google Play's brand has changed slightly in the color of the actual "Play" button - as per [Brand Guidelines](https://play.google.com/intl/en_us/badges/) \
F-Droid has some bold text in the "Get it on" and is longer that previously - as per [F-Droids badge Repo](https://github.com/f-droid/artwork/tree/master/badge)

It additionally adds some white padding around the badges (inherent to the logos provided by the vendors).