### PR TITLE
Update F-Droid image location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
        src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" />
 </a>
 
-<a href="https://f-droid.org/app/me.echeung.moemoekyun.fdroid">
+<a href="https://fdroid.gitlab.io/artwork/badge/get-it-on.png">
   <img height="80" alt="Get it on F-Droid"
        src="https://f-droid.org/badge/get-it-on.png">
 </a>

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
        src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" />
 </a>
 
-<a href="https://fdroid.gitlab.io/artwork/badge/get-it-on.png">
+<a href="https://f-droid.org/app/me.echeung.moemoekyun.fdroid">
   <img height="80" alt="Get it on F-Droid"
-       src="https://f-droid.org/badge/get-it-on.png">
+       src="https://fdroid.gitlab.io/artwork/badge/get-it-on.png">
 </a>
 
 


### PR DESCRIPTION
Current image for the F-Droid Get-it-on link is broken.

This is the recommended image based on the [F-Droid badge repo](https://gitlab.com/fdroid/artwork/tree/master/badge).