### PR TITLE
feat: add song progress bar in player

### DIFF
--- a/app/src/main/kotlin/me/echeung/moemoekyun/domain/radio/RadioService.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/domain/radio/RadioService.kt
@@ -24,6 +24,7 @@ import me.echeung.moemoekyun.util.ext.connectivityManager
 import me.echeung.moemoekyun.util.ext.launchIO
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 
@@ -61,7 +62,7 @@ class RadioService @Inject constructor(
                         currentSong = info?.song?.let(songConverter::toDomainSong)?.copy(
                             favorited = getFavoriteSongs.isFavorite(info.song.id),
                         ),
-                        startTime = info?.startTime,
+                        endTime = info?.startTime,
                         listeners = info?.listeners ?: 0,
                         requester = info?.requester?.displayName,
                         event = info?.event,
@@ -122,9 +123,16 @@ data class RadioState(
     val listeners: Int = 0,
     val requester: String? = null,
     val currentSong: DomainSong? = null,
-    val startTime: Instant? = null,
+    // The WebSocket "startTime" is actually the song's end time. Subtract duration to get real start.
+    val endTime: Instant? = null,
     val event: Event? = null,
 ) {
+    val startTime: Instant?
+        get() = endTime?.let { end ->
+            val durationSeconds = currentSong?.durationSeconds ?: return@let null
+            end - durationSeconds.seconds
+        }
+
     val albumArtUrl: String?
         get() = currentSong?.albumArtUrl ?: event?.image
 }

--- a/app/src/main/kotlin/me/echeung/moemoekyun/domain/songs/model/SongConverter.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/domain/songs/model/SongConverter.kt
@@ -3,7 +3,7 @@ package me.echeung.moemoekyun.domain.songs.model
 import me.echeung.moemoekyun.client.model.Song
 import me.echeung.moemoekyun.client.model.SongDescriptor
 import me.echeung.moemoekyun.util.PreferenceUtil
-import java.util.Locale
+import me.echeung.moemoekyun.util.ext.formatDuration
 import javax.inject.Inject
 
 class SongConverter @Inject constructor(private val preferenceUtil: PreferenceUtil) {
@@ -36,17 +36,7 @@ class SongConverter @Inject constructor(private val preferenceUtil: PreferenceUt
         }
         .joinToString()
 
-    private fun Song.duration(): String {
-        var minutes = (duration / 60).toLong()
-        val seconds = (duration % 60).toLong()
-        return if (minutes < 60) {
-            String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds)
-        } else {
-            val hours = minutes / 60
-            minutes %= 60
-            String.format(Locale.getDefault(), "%02d:%02d:%02d", hours, minutes, seconds)
-        }
-    }
+    private fun Song.duration(): String = duration.toLong().formatDuration()
 
     private fun Song.albumArtUrl(): String? {
         val album = albums?.firstOrNull { it.image != null }

--- a/app/src/main/kotlin/me/echeung/moemoekyun/ui/common/SongProgressBar.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/ui/common/SongProgressBar.kt
@@ -84,20 +84,22 @@ fun ExpandedSongProgressBar(progress: Float, durationSeconds: Long, modifier: Mo
             modifier = Modifier.fillMaxWidth(),
         )
 
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-        ) {
-            Text(
-                text = (progress * durationSeconds).toLong().formatDuration(),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.secondary,
-            )
-            Text(
-                text = durationSeconds.formatDuration(),
-                style = MaterialTheme.typography.labelSmall,
-                color = MaterialTheme.colorScheme.secondary,
-            )
+        if (durationSeconds > 0L) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = (progress * durationSeconds).toLong().formatDuration(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.secondary,
+                )
+                Text(
+                    text = durationSeconds.formatDuration(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.secondary,
+                )
+            }
         }
     }
 }

--- a/app/src/main/kotlin/me/echeung/moemoekyun/ui/common/SongProgressBar.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/ui/common/SongProgressBar.kt
@@ -1,0 +1,157 @@
+package me.echeung.moemoekyun.ui.common
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+import java.util.Locale
+
+private const val PROGRESS_BAR_ALPHA = 0.85f
+private const val TRACK_ALPHA_FRACTION = 0.25f
+
+/**
+ * Returns a [0, 1] progress value that ticks in real-time based on wall-clock elapsed time.
+ * Source-agnostic: pass any epoch-millisecond start time from WebSocket, local playback, etc.
+ * Returns 0 if duration or start time is unknown.
+ */
+@Composable
+fun rememberSongProgress(
+    startTimeEpochMs: Long?,
+    durationSeconds: Long,
+): Float {
+    var progress by remember(startTimeEpochMs, durationSeconds) {
+        mutableFloatStateOf(
+            if (startTimeEpochMs != null && durationSeconds > 0L) {
+                computeProgress(startTimeEpochMs, durationSeconds)
+            } else {
+                0f
+            },
+        )
+    }
+
+    LaunchedEffect(startTimeEpochMs, durationSeconds) {
+        if (startTimeEpochMs == null || durationSeconds <= 0L) {
+            progress = 0f
+            return@LaunchedEffect
+        }
+        while (true) {
+            progress = computeProgress(startTimeEpochMs, durationSeconds)
+            delay(500L)
+        }
+    }
+
+    return progress
+}
+
+private fun computeProgress(startTimeEpochMs: Long, durationSeconds: Long): Float =
+    ((System.currentTimeMillis() - startTimeEpochMs) / 1000f / durationSeconds).coerceIn(0f, 1f)
+
+/** Thin full-width bar for the top edge of the collapsed player strip. No corner radius. */
+@Composable
+fun CollapsedSongProgressBar(
+    progress: Float,
+    modifier: Modifier = Modifier,
+) {
+    SongProgressBar(
+        progress = progress,
+        trackHeight = 3.dp,
+        cornerRadius = 0.dp,
+        modifier = modifier.fillMaxWidth(),
+    )
+}
+
+/** Thicker rounded bar with elapsed / total time labels for the expanded player. */
+@Composable
+fun ExpandedSongProgressBar(
+    progress: Float,
+    durationSeconds: Long,
+    totalTime: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        SongProgressBar(
+            progress = progress,
+            trackHeight = 6.dp,
+            cornerRadius = 3.dp,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Text(
+                text = formatDuration((progress * durationSeconds).toLong()),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.secondary,
+            )
+            Text(
+                text = totalTime,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.secondary,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SongProgressBar(
+    progress: Float,
+    trackHeight: Dp,
+    cornerRadius: Dp,
+    modifier: Modifier = Modifier,
+) {
+    val accentColor = LocalAlbumArtAccentColor.current
+    val primary = MaterialTheme.colorScheme.primary
+    val fillColor = remember(accentColor, primary) {
+        (accentColor ?: primary).copy(alpha = PROGRESS_BAR_ALPHA)
+    }
+    val trackColor = remember(fillColor) {
+        fillColor.copy(alpha = fillColor.alpha * TRACK_ALPHA_FRACTION)
+    }
+
+    Canvas(modifier = modifier.height(trackHeight)) {
+        val radius = CornerRadius(cornerRadius.toPx())
+
+        drawRoundRect(color = trackColor, cornerRadius = radius)
+
+        val fillWidth = size.width * progress.coerceIn(0f, 1f)
+        if (fillWidth > 0f) {
+            drawRoundRect(
+                color = fillColor,
+                size = Size(fillWidth, size.height),
+                cornerRadius = radius,
+            )
+        }
+    }
+}
+
+private fun formatDuration(totalSeconds: Long): String {
+    val minutes = totalSeconds / 60
+    val seconds = totalSeconds % 60
+    return if (minutes < 60) {
+        String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds)
+    } else {
+        val hours = minutes / 60
+        String.format(Locale.getDefault(), "%02d:%02d:%02d", hours, minutes % 60, seconds)
+    }
+}

--- a/app/src/main/kotlin/me/echeung/moemoekyun/ui/common/SongProgressBar.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/ui/common/SongProgressBar.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
-import java.util.Locale
+import me.echeung.moemoekyun.util.ext.formatDuration
 
 private const val PROGRESS_BAR_ALPHA = 0.85f
 private const val TRACK_ALPHA_FRACTION = 0.25f
@@ -31,10 +31,7 @@ private const val TRACK_ALPHA_FRACTION = 0.25f
  * Returns 0 if duration or start time is unknown.
  */
 @Composable
-fun rememberSongProgress(
-    startTimeEpochMs: Long?,
-    durationSeconds: Long,
-): Float {
+fun rememberSongProgress(startTimeEpochMs: Long?, durationSeconds: Long): Float {
     var progress by remember(startTimeEpochMs, durationSeconds) {
         mutableFloatStateOf(
             if (startTimeEpochMs != null && durationSeconds > 0L) {
@@ -50,7 +47,7 @@ fun rememberSongProgress(
             progress = 0f
             return@LaunchedEffect
         }
-        while (true) {
+        while (progress < 1f) {
             progress = computeProgress(startTimeEpochMs, durationSeconds)
             delay(500L)
         }
@@ -64,10 +61,7 @@ private fun computeProgress(startTimeEpochMs: Long, durationSeconds: Long): Floa
 
 /** Thin full-width bar for the top edge of the collapsed player strip. No corner radius. */
 @Composable
-fun CollapsedSongProgressBar(
-    progress: Float,
-    modifier: Modifier = Modifier,
-) {
+fun CollapsedSongProgressBar(progress: Float, modifier: Modifier = Modifier) {
     SongProgressBar(
         progress = progress,
         trackHeight = 3.dp,
@@ -78,12 +72,7 @@ fun CollapsedSongProgressBar(
 
 /** Thicker rounded bar with elapsed / total time labels for the expanded player. */
 @Composable
-fun ExpandedSongProgressBar(
-    progress: Float,
-    durationSeconds: Long,
-    totalTime: String,
-    modifier: Modifier = Modifier,
-) {
+fun ExpandedSongProgressBar(progress: Float, durationSeconds: Long, modifier: Modifier = Modifier) {
     Column(
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -100,12 +89,12 @@ fun ExpandedSongProgressBar(
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Text(
-                text = formatDuration((progress * durationSeconds).toLong()),
+                text = (progress * durationSeconds).toLong().formatDuration(),
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.secondary,
             )
             Text(
-                text = totalTime,
+                text = durationSeconds.formatDuration(),
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.secondary,
             )
@@ -114,12 +103,7 @@ fun ExpandedSongProgressBar(
 }
 
 @Composable
-private fun SongProgressBar(
-    progress: Float,
-    trackHeight: Dp,
-    cornerRadius: Dp,
-    modifier: Modifier = Modifier,
-) {
+private fun SongProgressBar(progress: Float, trackHeight: Dp, cornerRadius: Dp, modifier: Modifier = Modifier) {
     val accentColor = LocalAlbumArtAccentColor.current
     val primary = MaterialTheme.colorScheme.primary
     val fillColor = remember(accentColor, primary) {
@@ -142,16 +126,5 @@ private fun SongProgressBar(
                 cornerRadius = radius,
             )
         }
-    }
-}
-
-private fun formatDuration(totalSeconds: Long): String {
-    val minutes = totalSeconds / 60
-    val seconds = totalSeconds % 60
-    return if (minutes < 60) {
-        String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds)
-    } else {
-        val hours = minutes / 60
-        String.format(Locale.getDefault(), "%02d:%02d:%02d", hours, minutes % 60, seconds)
     }
 }

--- a/app/src/main/kotlin/me/echeung/moemoekyun/ui/common/SongProgressBar.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/ui/common/SongProgressBar.kt
@@ -64,7 +64,7 @@ private fun computeProgress(startTimeEpochMs: Long, durationSeconds: Long): Floa
 fun CollapsedSongProgressBar(progress: Float, modifier: Modifier = Modifier) {
     SongProgressBar(
         progress = progress,
-        trackHeight = 3.dp,
+        trackHeight = 2.dp,
         cornerRadius = 0.dp,
         modifier = modifier.fillMaxWidth(),
     )

--- a/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/Player.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/Player.kt
@@ -87,8 +87,8 @@ import me.echeung.moemoekyun.ui.common.CollapsedSongProgressBar
 import me.echeung.moemoekyun.ui.common.ExpandedSongProgressBar
 import me.echeung.moemoekyun.ui.common.LocalAlbumArtAccentColor
 import me.echeung.moemoekyun.ui.common.rememberSongProgress
-import kotlin.time.ExperimentalTime
 import me.echeung.moemoekyun.util.ext.copyToClipboard
+import kotlin.time.ExperimentalTime
 
 /** Reserved scroll space for the collapsed player strip (content height, excluding nav bar inset). */
 val PlayerPeekHeight = 80.dp
@@ -484,8 +484,7 @@ private fun StationPicker(radioState: RadioState, onClickStation: (Station) -> U
     }
 }
 
-@OptIn(UnstableApi::class)
-@OptIn(ExperimentalTime::class)
+@OptIn(UnstableApi::class, ExperimentalTime::class)
 @Composable
 private fun SongInfo(
     radioState: RadioState,

--- a/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/Player.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/Player.kt
@@ -133,45 +133,48 @@ fun PlayerScaffold(
         },
     )
 
-    BottomSheetScaffold(
-        scaffoldState = scaffoldState,
-        sheetContent = {
-            ExpandedPlayerContent(
-                radioState = radioState,
-                playPauseButtonState = playPauseButtonState,
-                accentColor = accentColor,
-                visualizerState = visualizerState,
-                isVisualizerEnabled = isVisualizerEnabled,
-                onClickStation = onClickStation,
-                onClickHistory = onClickHistory,
-                toggleFavorite = toggleFavorite,
-                onClickCollapse = {
-                    scope.launch {
-                        scaffoldState.bottomSheetState.hide()
-                    }
-                },
-            )
-        },
-        sheetContainerColor = MaterialTheme.colorScheme.background,
-        sheetMaxWidth = Dp.Unspecified,
-        sheetPeekHeight = 0.dp,
-        sheetShape = RoundedCornerShape(0.dp),
-        sheetDragHandle = {},
-        modifier = modifier,
-    ) { contentPadding ->
-        Box {
-            content(contentPadding)
+    CompositionLocalProvider(
+        LocalAlbumArtAccentColor provides accentColor,
+    ) {
+        BottomSheetScaffold(
+            scaffoldState = scaffoldState,
+            sheetContent = {
+                ExpandedPlayerContent(
+                    radioState = radioState,
+                    playPauseButtonState = playPauseButtonState,
+                    visualizerState = visualizerState,
+                    isVisualizerEnabled = isVisualizerEnabled,
+                    onClickStation = onClickStation,
+                    onClickHistory = onClickHistory,
+                    toggleFavorite = toggleFavorite,
+                    onClickCollapse = {
+                        scope.launch {
+                            scaffoldState.bottomSheetState.hide()
+                        }
+                    },
+                )
+            },
+            sheetContainerColor = MaterialTheme.colorScheme.background,
+            sheetMaxWidth = Dp.Unspecified,
+            sheetPeekHeight = 0.dp,
+            sheetShape = RoundedCornerShape(0.dp),
+            sheetDragHandle = {},
+            modifier = modifier,
+        ) { contentPadding ->
+            Box {
+                content(contentPadding)
 
-            CollapsedPlayerContent(
-                radioState = radioState,
-                playPauseButtonState = playPauseButtonState,
-                toggleFavorite = toggleFavorite,
-                onClick = {
-                    scope.launch {
-                        scaffoldState.bottomSheetState.expand()
-                    }
-                },
-            )
+                CollapsedPlayerContent(
+                    radioState = radioState,
+                    playPauseButtonState = playPauseButtonState,
+                    toggleFavorite = toggleFavorite,
+                    onClick = {
+                        scope.launch {
+                            scaffoldState.bottomSheetState.expand()
+                        }
+                    },
+                )
+            }
         }
     }
 }
@@ -270,7 +273,6 @@ private fun BoxScope.CollapsedPlayerContent(
 private fun ExpandedPlayerContent(
     radioState: RadioState,
     playPauseButtonState: PlayPauseButtonState,
-    accentColor: Color?,
     visualizerState: VisualizerState,
     isVisualizerEnabled: Boolean,
     onClickCollapse: () -> Unit,
@@ -285,7 +287,6 @@ private fun ExpandedPlayerContent(
     ) {
         CompositionLocalProvider(
             LocalContentColor provides contentColorFor(surfaceColor),
-            LocalAlbumArtAccentColor provides accentColor,
         ) {
             BoxWithConstraints {
                 if (maxWidth < maxHeight) {

--- a/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/Player.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/Player.kt
@@ -551,7 +551,6 @@ private fun SongInfo(
                 ExpandedSongProgressBar(
                     progress = progress,
                     durationSeconds = durationSeconds,
-                    totalTime = currentSong.duration,
                     modifier = Modifier.padding(horizontal = 8.dp),
                 )
             }

--- a/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/Player.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/Player.kt
@@ -83,7 +83,11 @@ import me.echeung.moemoekyun.domain.radio.RadioState
 import me.echeung.moemoekyun.service.VisualizerState
 import me.echeung.moemoekyun.ui.common.AlbumArt
 import me.echeung.moemoekyun.ui.common.AudioVisualizer
+import me.echeung.moemoekyun.ui.common.CollapsedSongProgressBar
+import me.echeung.moemoekyun.ui.common.ExpandedSongProgressBar
 import me.echeung.moemoekyun.ui.common.LocalAlbumArtAccentColor
+import me.echeung.moemoekyun.ui.common.rememberSongProgress
+import kotlin.time.ExperimentalTime
 import me.echeung.moemoekyun.util.ext.copyToClipboard
 
 /** Reserved scroll space for the collapsed player strip (content height, excluding nav bar inset). */
@@ -172,7 +176,7 @@ fun PlayerScaffold(
     }
 }
 
-@OptIn(UnstableApi::class)
+@OptIn(UnstableApi::class, ExperimentalTime::class)
 @Composable
 private fun BoxScope.CollapsedPlayerContent(
     radioState: RadioState,
@@ -181,6 +185,9 @@ private fun BoxScope.CollapsedPlayerContent(
     onClick: () -> Unit,
 ) {
     val surfaceColor = MaterialTheme.colorScheme.surface
+    val durationSeconds = radioState.currentSong?.durationSeconds ?: 0L
+    val startTimeMs = radioState.startTime?.toEpochMilliseconds()
+    val progress = rememberSongProgress(startTimeMs, durationSeconds)
 
     Surface(
         modifier = Modifier
@@ -190,6 +197,9 @@ private fun BoxScope.CollapsedPlayerContent(
         contentColor = contentColorFor(surfaceColor),
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {
+            if (durationSeconds > 0L) {
+                CollapsedSongProgressBar(progress = progress)
+            }
             HorizontalDivider()
 
             Row(
@@ -475,6 +485,7 @@ private fun StationPicker(radioState: RadioState, onClickStation: (Station) -> U
 }
 
 @OptIn(UnstableApi::class)
+@OptIn(ExperimentalTime::class)
 @Composable
 private fun SongInfo(
     radioState: RadioState,
@@ -484,6 +495,9 @@ private fun SongInfo(
 ) {
     val context = LocalContext.current
     val currentSong = radioState.currentSong
+    val durationSeconds = currentSong?.durationSeconds ?: 0L
+    val startTimeMs = radioState.startTime?.toEpochMilliseconds()
+    val progress = rememberSongProgress(startTimeMs, durationSeconds)
 
     Column(
         modifier = Modifier
@@ -532,6 +546,15 @@ private fun SongInfo(
                             },
                     )
                 }
+            }
+
+            if (durationSeconds > 0L) {
+                ExpandedSongProgressBar(
+                    progress = progress,
+                    durationSeconds = durationSeconds,
+                    totalTime = currentSong.duration,
+                    modifier = Modifier.padding(horizontal = 8.dp),
+                )
             }
         }
 

--- a/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/Player.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/Player.kt
@@ -547,13 +547,11 @@ private fun SongInfo(
                 }
             }
 
-            if (durationSeconds > 0L) {
-                ExpandedSongProgressBar(
-                    progress = progress,
-                    durationSeconds = durationSeconds,
-                    modifier = Modifier.padding(horizontal = 8.dp),
-                )
-            }
+            ExpandedSongProgressBar(
+                progress = progress,
+                durationSeconds = durationSeconds,
+                modifier = Modifier.padding(horizontal = 8.dp),
+            )
         }
 
         Row(

--- a/app/src/main/kotlin/me/echeung/moemoekyun/util/ext/DurationExtensions.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/util/ext/DurationExtensions.kt
@@ -1,0 +1,14 @@
+package me.echeung.moemoekyun.util.ext
+
+import java.util.Locale
+
+fun Long.formatDuration(): String {
+    val minutes = this / 60
+    val seconds = this % 60
+    return if (minutes < 60) {
+        String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds)
+    } else {
+        val hours = minutes / 60
+        String.format(Locale.getDefault(), "%02d:%02d:%02d", hours, minutes % 60, seconds)
+    }
+}

--- a/app/src/main/kotlin/me/echeung/moemoekyun/util/ext/DurationExtensions.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/util/ext/DurationExtensions.kt
@@ -1,14 +1,11 @@
 package me.echeung.moemoekyun.util.ext
 
-import java.util.Locale
+import kotlin.time.Duration.Companion.seconds
 
-fun Long.formatDuration(): String {
-    val minutes = this / 60
-    val seconds = this % 60
-    return if (minutes < 60) {
-        String.format(Locale.getDefault(), "%02d:%02d", minutes, seconds)
-    } else {
-        val hours = minutes / 60
-        String.format(Locale.getDefault(), "%02d:%02d:%02d", hours, minutes % 60, seconds)
+fun Long.formatDuration(): String = seconds.toComponents { hours, minutes, seconds, _ ->
+    buildString {
+        if (hours > 0) append("$hours:")
+        append(if (hours > 0) minutes.toString().padStart(2, '0') else minutes)
+        append(":${seconds.toString().padStart(2, '0')}")
     }
 }


### PR DESCRIPTION
Introduces SongProgressBar.kt with rememberSongProgress (source-agnostic,
epoch-ms based ticker), CollapsedSongProgressBar (thin 3dp edge bar), and
ExpandedSongProgressBar (6dp rounded bar with elapsed/total time labels).
Uses album-art accent colour at 0.85 alpha (vs visualiser's 0.33). Hidden
when durationSeconds is unknown. Integrated into both collapsed strip (top
edge) and expanded player (between artist info and playback controls).

https://claude.ai/code/session_011qRjEzSALJFxGY4TsHeskT