### PR TITLE
feat: store and propagate both username and displayName for authenticated user

### DIFF
--- a/app/src/main/kotlin/me/echeung/moemoekyun/client/api/data/DataTransformer.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/client/api/data/DataTransformer.kt
@@ -16,6 +16,7 @@ import me.echeung.moemoekyun.fragment.SongListFields
 
 fun UserQuery.User.transform() = User(
     this.uuid,
+    this.username,
     this.displayName!!,
     this.avatarImage,
     this.bannerImage,

--- a/app/src/main/kotlin/me/echeung/moemoekyun/client/model/User.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/client/model/User.kt
@@ -3,4 +3,10 @@ package me.echeung.moemoekyun.client.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class User(val uuid: String, val displayName: String, val avatarImage: String?, val bannerImage: String?)
+data class User(
+    val uuid: String,
+    val username: String,
+    val displayName: String,
+    val avatarImage: String?,
+    val bannerImage: String?,
+)

--- a/app/src/main/kotlin/me/echeung/moemoekyun/domain/user/model/DomainUser.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/domain/user/model/DomainUser.kt
@@ -1,3 +1,3 @@
 package me.echeung.moemoekyun.domain.user.model
 
-data class DomainUser(val username: String, val avatarUrl: String?, val bannerUrl: String?)
+data class DomainUser(val username: String, val displayName: String, val avatarUrl: String?, val bannerUrl: String?)

--- a/app/src/main/kotlin/me/echeung/moemoekyun/domain/user/model/UserConverter.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/domain/user/model/UserConverter.kt
@@ -6,7 +6,8 @@ import javax.inject.Inject
 class UserConverter @Inject constructor() {
 
     fun toDomainUser(user: User): DomainUser = DomainUser(
-        username = user.displayName,
+        username = user.username,
+        displayName = user.displayName,
         avatarUrl = "$CDN_AVATAR_URL/${user.avatarImage}".takeIf { user.avatarImage != null },
         bannerUrl = "$CDN_BANNER_URL/${user.bannerImage}".takeIf { user.bannerImage != null },
     )

--- a/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/AuthedHomeContent.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/AuthedHomeContent.kt
@@ -155,7 +155,7 @@ private fun UserInfo(user: DomainUser, onClickLogOut: () -> Unit) {
 
             Text(
                 modifier = Modifier.weight(1f),
-                text = user.username,
+                text = user.displayName,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )


### PR DESCRIPTION
Previously only displayName was stored from the GraphQL response, then
incorrectly mapped to DomainUser.username. Now both fields are carried
through the full pipeline so the profile link uses the real username
while the display text shows the displayName.

https://claude.ai/code/session_01FH9K9tJJhT4zAAvCn5XnbN