### PR TITLE
feat: use SSE for start time info

### DIFF
--- a/app/src/main/kotlin/me/echeung/moemoekyun/client/api/socket/ResponseModel.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/client/api/socket/ResponseModel.kt
@@ -1,7 +1,6 @@
 package me.echeung.moemoekyun.client.api.socket
 
 import kotlinx.serialization.DeserializationStrategy
-import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonContentPolymorphicSerializer
 import kotlinx.serialization.json.JsonElement
@@ -34,16 +33,7 @@ sealed interface WebsocketResponse {
     @Serializable
     data class Update(val t: String?, val d: Details?) : WebsocketResponse {
         @Serializable
-        data class Details(
-            val song: Song?,
-            val requester: User?,
-            val event: Event?,
-            val listeners: Int,
-            // The wire field is named "startTime" but is actually the song's *end* time (ISO-8601);
-            // Consumers should subtract the duration to derive the real start time.
-            @SerialName("startTime")
-            val endTime: String? = null,
-        )
+        data class Details(val song: Song?, val requester: User?, val event: Event?, val listeners: Int)
 
         fun isValidUpdate(): Boolean = (
             t == TRACK_UPDATE ||

--- a/app/src/main/kotlin/me/echeung/moemoekyun/domain/radio/RadioService.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/domain/radio/RadioService.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import me.echeung.moemoekyun.client.api.Station
 import me.echeung.moemoekyun.client.api.socket.Socket
 import me.echeung.moemoekyun.client.api.sse.QueueSse
@@ -44,32 +45,31 @@ class RadioService @Inject constructor(
     init {
         scope.launchIO {
             songUpdateMapper.flow(socket.flow).collectLatest { update ->
-                val current = _state.value
-                // The WS TRACK_UPDATE carries startTime atomically with the song, so we always have a
-                // start time synced to the current song (no stale value, no gap waiting on a second
-                // stream). This is currently the sole source of startTime; the SSE metadata stream is
-                // kept connected but no longer feeds startTime (see the SSE collector below for why).
-                // Queue/notification updates carry no song or startTime; keep the current value then.
-                _state.value = current.copy(
+                // The WS owns song content (title/artist/duration/album art); the SSE owns timing.
+                // startTime is driven solely by the SSE metadata stream (see the SSE collector below),
+                // which reports the song's true start (accurate for mid-song joins too).
+                _state.value = _state.value.copy(
                     currentSong = update.currentSong,
                     listeners = update.listeners,
                     requester = update.requester,
                     event = update.event,
-                    startTime = update.startTime ?: current.startTime,
                 )
             }
         }
 
         scope.launchIO {
-            sse.flow.collectLatest { _ ->
-                // TODO: The SSE metadata stream also carries a startedAt, but we find it too bothersome
-                // to deal with the drift with the WS updates at the moment.
-                // This is particularly annoying to deal with since the MediaSession actually calculates its own
-                // progress based on a provided start time in PlaybackPlayer (PositionSupplier.getExtrapolating).
-
-                // val startedAt = metadata.startedAt?.let(Instant::parse) ?: return@collectLatest
-                // _state.value = _state.value.copy(startTime = startedAt)
-            }
+            // The SSE metadata stream is the authoritative timing source: its startedAt is the song's
+            // true start (accurate even when joining mid-song), unlike the WS which reports the end
+            // time. We only need the start time here — the WS drives all song content — so map to
+            // startedAt and dedup, updating startTime only when it actually changes (i.e. a new song).
+            sse.flow
+                .map { it.startedAt?.let(Instant::parse) }
+                .distinctUntilChanged()
+                .collectLatest { startedAt ->
+                    if (startedAt != null) {
+                        _state.value = _state.value.copy(startTime = startedAt)
+                    }
+                }
         }
 
         scope.launchIO {

--- a/app/src/main/kotlin/me/echeung/moemoekyun/domain/radio/SongUpdateMapper.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/domain/radio/SongUpdateMapper.kt
@@ -12,15 +12,11 @@ import me.echeung.moemoekyun.domain.songs.model.SongConverter
 import me.echeung.moemoekyun.util.PreferenceUtil
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.time.Duration.Companion.seconds
-import kotlin.time.ExperimentalTime
-import kotlin.time.Instant
 
 /**
  * Transforms the raw WebSocket flow into [SongUpdate] values, re-emitting whenever
  * the song, favorites, or romaji preference changes.
  */
-@OptIn(ExperimentalTime::class)
 @Singleton
 class SongUpdateMapper @Inject constructor(
     private val songConverter: SongConverter,
@@ -43,17 +39,13 @@ class SongUpdateMapper @Inject constructor(
                 listeners = info?.listeners ?: 0,
                 requester = info?.requester?.displayName,
                 event = info?.event,
-                startTime = info?.endTime?.let(Instant::parse)
-                    ?.minus((info.song?.duration ?: 0).seconds),
             )
         }
 }
 
-@OptIn(ExperimentalTime::class)
 data class SongUpdate(
     val currentSong: DomainSong? = null,
     val listeners: Int = 0,
     val requester: String? = null,
     val event: Event? = null,
-    val startTime: Instant? = null,
 )

--- a/app/src/main/kotlin/me/echeung/moemoekyun/util/ext/DurationExtensions.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/util/ext/DurationExtensions.kt
@@ -5,9 +5,9 @@ import kotlin.time.Duration.Companion.seconds
 /**
  * Elapsed play time in ms for a song, clamped to [0, duration].
  *
- * Staleness from WS/SSE drift is handled upstream: RadioService clears the startTime when a new song
- * arrives, so a non-null start time here always belongs to the current song. This only clamps the
- * value into range so callers extrapolating from it stay stable at the song's start and end.
+ * The start time comes from the SSE metadata stream (the song's true start), so a non-null value
+ * always belongs to the current song. This only clamps the value into range so callers extrapolating
+ * from it stay stable at the song's start and end.
  */
 fun songElapsedMs(startTimeEpochMs: Long, durationSeconds: Long, nowMs: Long = System.currentTimeMillis()): Long {
     val elapsedMs = nowMs - startTimeEpochMs


### PR DESCRIPTION
This is still really scuffed in dealing with drift + interactions with how MediaSession uses start time / duration to extrapolate progress.