### PR TITLE
Avoid flashing unauthenticated content while loading user data

### DIFF
--- a/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/HomeScreen.kt
@@ -108,8 +108,8 @@ fun HomeScreen(
                     modifier = Modifier.fillMaxSize(),
                 ) {
                     val contentPadding = scaffoldPadding + playerPadding
-                    if (isAuthenticated) {
-                        AuthedHomeContent(
+                    when {
+                        isAuthenticated -> AuthedHomeContent(
                             user = state.user!!,
                             onClickLogOut = screenModel::logout,
                             favorites = state.filteredFavorites,
@@ -123,8 +123,14 @@ fun HomeScreen(
                             onShowSongs = { songs -> onShowHistory(songs, null) },
                             contentPadding = contentPadding,
                         )
-                    } else {
-                        UnauthedHomeContent(
+
+                        // Already have a token but the user data is still loading, so avoid
+                        // flashing the unauthenticated content.
+                        state.isLoadingUser -> LoadingHomeContent(
+                            contentPadding = contentPadding,
+                        )
+
+                        else -> UnauthedHomeContent(
                             onNavigateLogin = onNavigateLogin,
                             onNavigateRegister = onNavigateRegister,
                             contentPadding = contentPadding,

--- a/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/HomeScreen.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/HomeScreen.kt
@@ -124,8 +124,6 @@ fun HomeScreen(
                             contentPadding = contentPadding,
                         )
 
-                        // Already have a token but the user data is still loading, so avoid
-                        // flashing the unauthenticated content.
                         state.isLoadingUser -> LoadingHomeContent(
                             contentPadding = contentPadding,
                         )

--- a/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/HomeScreenModel.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/HomeScreenModel.kt
@@ -84,6 +84,7 @@ class HomeScreenModel @Inject constructor(
                     _state.update { state ->
                         state.copy(
                             user = it,
+                            hasAuthToken = getAuthenticatedUser.isAuthenticated(),
                         )
                     }
                 }
@@ -184,6 +185,7 @@ class HomeScreenModel @Inject constructor(
     @Immutable
     data class State(
         val user: DomainUser? = null,
+        val hasAuthToken: Boolean = false,
         val favorites: ImmutableList<DomainSong>? = null,
         val accentColor: Color? = null,
         val searchQuery: String? = null,
@@ -192,6 +194,13 @@ class HomeScreenModel @Inject constructor(
     ) {
         val filteredFavorites: ImmutableList<DomainSong>?
             get() = favorites?.search(searchQuery)
+
+        /**
+         * True when a token is stored but the user data hasn't loaded yet, i.e. we're likely
+         * authenticated and should avoid flashing the unauthenticated content.
+         */
+        val isLoadingUser: Boolean
+            get() = user == null && hasAuthToken
     }
 }
 

--- a/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/LoadingHomeContent.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/LoadingHomeContent.kt
@@ -1,0 +1,40 @@
+package me.echeung.moemoekyun.ui.screen.home
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.PreviewLightDark
+import androidx.compose.ui.unit.dp
+import me.echeung.moemoekyun.ui.theme.AppTheme
+
+/**
+ * Placeholder shown while the authenticated user's data is still loading. Kept intentionally
+ * simple for now, but split out so it can be replaced with richer placeholder content later.
+ */
+@Composable
+fun LoadingHomeContent(
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(contentPadding),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@PreviewLightDark
+@Composable
+private fun LoadingHomeContentPreview() {
+    AppTheme {
+        LoadingHomeContent()
+    }
+}

--- a/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/LoadingHomeContent.kt
+++ b/app/src/main/kotlin/me/echeung/moemoekyun/ui/screen/home/LoadingHomeContent.kt
@@ -13,14 +13,10 @@ import androidx.compose.ui.unit.dp
 import me.echeung.moemoekyun.ui.theme.AppTheme
 
 /**
- * Placeholder shown while the authenticated user's data is still loading. Kept intentionally
- * simple for now, but split out so it can be replaced with richer placeholder content later.
+ * Placeholder shown while the authenticated user's data is still loading.
  */
 @Composable
-fun LoadingHomeContent(
-    modifier: Modifier = Modifier,
-    contentPadding: PaddingValues = PaddingValues(0.dp),
-) {
+fun LoadingHomeContent(modifier: Modifier = Modifier, contentPadding: PaddingValues = PaddingValues(0.dp)) {
     Box(
         modifier = modifier
             .fillMaxSize()


### PR DESCRIPTION
## Summary
This PR improves the user experience by preventing the unauthenticated home screen from briefly appearing when the app has a valid authentication token but is still loading the user's data.

## Key Changes
- **New `LoadingHomeContent` composable**: A simple loading placeholder with a centered progress indicator, intentionally kept minimal for future enhancement
- **Updated `HomeScreen` logic**: Changed from if/else to when expression to handle three states:
  - Authenticated with loaded user data → show `AuthedHomeContent`
  - Has auth token but user data still loading → show `LoadingHomeContent`
  - No auth token → show `UnauthedHomeContent`
- **Enhanced `HomeScreenModel.State`**: 
  - Added `hasAuthToken` boolean to track whether an authentication token is stored
  - Added computed `isLoadingUser` property to detect the intermediate loading state
  - Updated user data loading to set `hasAuthToken` when user is fetched

## Implementation Details
The fix leverages the distinction between having a stored authentication token (`hasAuthToken`) and having loaded user data (`user != null`). When a token exists but user data hasn't loaded yet, the app now shows a loading indicator instead of the unauthenticated screen, providing a smoother experience on app startup or token refresh scenarios.

https://claude.ai/code/session_018tomufwA5vw5aNUZgYPt54